### PR TITLE
Dev.emilos.use style and class directly

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=auto

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,5 @@ node_js:
   - '6'
   - '5'
   - '4'
-  - '0.12'
 before_install:
   - 'npm install -g npm@latest'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
+
 node_js:
-  - '6'
-  - '5'
-  - '4'
-before_install:
-  - 'npm install -g npm@latest'
+  - 'node'
+  - 6
+  - 4

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -7,7 +7,7 @@ import plugin from '..';
 const filecontents = fs.readFileSync(path.resolve(__dirname, './test.spec.css'), 'utf8');
 
 test('Must include css', async t => {
-	const actual = `<div><link href="./test.spec.css" module/></div>`;
+	const actual = `<div><link href="./test/test.spec.css" module/></div>`;
 	const expected = `<div><style>${filecontents}</style></div>`;
 
 	const {html} = await posthtml().use(plugin({
@@ -18,7 +18,7 @@ test('Must include css', async t => {
 });
 
 test('Must replace html classes with processed ones', async t => {
-	const actual = `<link href="./test.spec.css" module/><div classname="root"></div>`;
+	const actual = `<link href="./test/test.spec.css" module/><div classname="root"></div>`;
 	const expected = `<style>${filecontents}</style><div class="root"></div>`;
 
 	const {html} = await posthtml().use(plugin({
@@ -29,7 +29,7 @@ test('Must replace html classes with processed ones', async t => {
 });
 
 test('Must keep previous classes on html elements', async t => {
-	const actual = `<link href="./test.spec.css" module/><div classname="root" class="div-class"></div>`;
+	const actual = `<link href="./test/test.spec.css" module/><div classname="root" class="div-class"></div>`;
 	const expected = `<style>${filecontents}</style><div class="div-class root"></div>`;
 
 	const {html} = await posthtml().use(plugin({
@@ -72,9 +72,23 @@ test('Must be able to compose styles from file', async t => {
 	t.is(html, expected);
 });
 
+test('Must be able to override the style selector', async t => {
+	const actual = '<style>.root {color: red;}</style><div classname="root"></div>';
+	const expected = `<style>._test_index_spec__root {color: red;}</style><div class="_test_index_spec__root"></div>`;
+	const {html} = await posthtml().use(plugin({from: __filename, selectors: {style: 'style'}})).process(actual);
+	t.is(html.replace(/(\n|\t)/g, ''), expected);
+});
+
+test('Must be able to override the class selector', async t => {
+	const actual = '<style>.root {color: red;}</style><div class="root"></div>';
+	const expected = `<style>._test_index_spec__root {color: red;}</style><div class="_test_index_spec__root"></div>`;
+	const {html} = await posthtml().use(plugin({from: __filename, selectors: {style: 'style'}, attributes: {class: 'class'}})).process(actual);
+	t.is(html.replace(/(\n|\t)/g, ''), expected);
+});
+
 test('Must generate default classnames if generateScopedName is undefined', async t => {
 	const actual = '<style module>.root {color: red;}</style><div classname="root"></div>';
-	const expected = `<style>._index_spec__root {color: red;}</style><div class="_index_spec__root"></div>`;
+	const expected = `<style>._test_index_spec__root {color: red;}</style><div class="_test_index_spec__root"></div>`;
 	const {html} = await posthtml().use(plugin({from: __filename})).process(actual);
 	t.is(html.replace(/(\n|\t)/g, ''), expected);
 });


### PR DESCRIPTION
Hey,

thanks for the great plugin! I was wondering if it would be possible to use `<style>` tag directly without the `module` attribute and avoid using the `classname` attribute in favor of the `class` attribute.

I didn't want to break anything so it's backwards compatible, the idea is that we can override the selectors and attributes plus it is possible to use the `class` attribute by filtering out the class name that was processed.

If you see anything that should be fixed then please feel free to let me know or change it however you like, I tried to follow current guidelines.

I also fixed some linting errors and made the tests pass locally.